### PR TITLE
myip: removes trailing newline

### DIFF
--- a/myip/main.go
+++ b/myip/main.go
@@ -7,6 +7,6 @@ type Myip struct{}
 
 // Return the public IP address of the current Dagger engine
 func (m *Myip) IP(ctx context.Context) (string, error) {
-	code := `import requests as r; print(r.get('https://api.ipify.org?format=json').json()['ip'])`
+	code := `import sys,requests as r; sys.stdout.write(r.get('https://api.ipify.org?format=json').json()['ip'])`
 	return dag.InlinePython().WithPackage("requests").Code(code).Stdout(ctx)
 }


### PR DESCRIPTION
can also be done with `print(..., end="")`