### PR TITLE
make ttlsh easier to use by making args optional

### DIFF
--- a/ttlsh/go.mod
+++ b/ttlsh/go.mod
@@ -5,6 +5,7 @@ go 1.21.3
 require (
 	github.com/99designs/gqlgen v0.17.31
 	github.com/Khan/genqlient v0.6.0
+	github.com/docker/docker v24.0.7+incompatible
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/sync v0.3.0
 )

--- a/ttlsh/go.sum
+++ b/ttlsh/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/docker/docker v24.0.7+incompatible h1:Wo6l37AuwP3JaMnZa226lzVXGA3F9Ig1seQen0cKYlM=
+github.com/docker/docker v24.0.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/ttlsh/main.go
+++ b/ttlsh/main.go
@@ -3,12 +3,24 @@ package main
 import (
 	"context"
 	"fmt"
+
+	"github.com/docker/docker/pkg/namesgenerator"
 )
 
 // A Dagger module to publish containers to ttl.sh, a throaway public registry
 type Ttlsh struct{}
 
 // Publish a container to ttl.sh
-func (m *Ttlsh) Publish(ctx context.Context, ctr *Container, repo, tag string) (string, error) {
-	return ctr.Publish(ctx, fmt.Sprintf("ttl.sh/%s:%s", repo, tag))
+func (m *Ttlsh) Publish(
+	ctx context.Context,
+	// the container to publish
+	ctr *Container,
+	// the repo to publish to, defaults to a random name
+	repo Optional[string],
+	// the tag to publish to, defaults to 10m
+	tag Optional[string],
+) (string, error) {
+	repoVal := repo.GetOr(namesgenerator.GetRandomName(0))
+	tagVal := tag.GetOr("10m")
+	return ctr.Publish(ctx, fmt.Sprintf("ttl.sh/%s:%s", repoVal, tagVal))
 }


### PR DESCRIPTION
Now it can be used as easy as:
```go
dag.Ttlsh().Publish(ctx, ctr)
```