### PR TITLE
fix: change defaults for v0.9.11

### DIFF
--- a/dagger/engine.go
+++ b/dagger/engine.go
@@ -132,7 +132,7 @@ func (e *EngineSource) CLI(
 	arch string,
 	// Registry from which to auto-pull the worker container image
 	// +optional
-	// +default=registry.dagger.io/engine
+	// +default="registry.dagger.io/engine"
 	workerRegistry string,
 	// Version of the Dagger CLI to build
 	// +optional

--- a/docker/main.go
+++ b/docker/main.go
@@ -22,7 +22,7 @@ type Docker struct {
 func (e *Docker) Engine(
 	// Docker Engine version
 	// +optional
-	// +default=24.0
+	// +default="24.0"
 	version string,
 ) *Service {
 	return dag.Container().
@@ -50,7 +50,7 @@ func (e *Docker) Engine(
 func (d *Docker) CLI(
 	// Version of the Docker CLI to run.
 	// +optional
-	// +default=24.0
+	// +default="24.0"
 	version string,
 	// Specify the Docker Engine to connect to.
 	// By default, run an ephemeral engine.
@@ -86,7 +86,7 @@ func (c *CLI) Pull(
 	repository,
 	// The docker image tag to pull
 	// +optional
-	// +default=latest
+	// +default="latest"
 	tag string) (*Image, error) {
 	return c.Import(ctx, dag.Container().From(repository+":"+tag))
 }
@@ -98,7 +98,7 @@ func (c *CLI) Push(
 	repository,
 	// The tag to push to.
 	// +optional
-	// +default=latest
+	// +default="latest"
 	tag string,
 ) (string, error) {
 	img, err := c.Image(ctx, repository, tag)
@@ -115,7 +115,7 @@ func (c *CLI) WithPull(
 	repository,
 	// The tag to pull from
 	// +optional
-	// +default=latest
+	// +default="latest"
 	tag string,
 ) (*CLI, error) {
 	_, err := c.Pull(ctx, repository, tag)
@@ -129,7 +129,7 @@ func (c *CLI) WithPush(
 	repository,
 	// The tag to push to.
 	// +optional
-	// +default=latest
+	// +default="latest"
 	tag string,
 ) (*CLI, error) {
 	img, err := c.Image(ctx, repository, tag)
@@ -176,7 +176,7 @@ func (c *CLI) Image(
 	repository,
 	// The tag of the image
 	// +optional
-	// +default=latest
+	// +default="latest"
 	tag string,
 ) (*Image, error) {
 	images, err := c.Images(ctx, repository, tag)
@@ -197,7 +197,7 @@ func (c *CLI) Run(
 	name,
 	// Tag of the image to run.
 	// +optional
-	// +default=latest
+	// +default="latest"
 	tag string,
 	// Additional arguments
 	// +optional

--- a/hello/main.go
+++ b/hello/main.go
@@ -19,11 +19,11 @@ type Hello struct{}
 func (hello *Hello) Hello(ctx context.Context,
 	// Change the greeting
 	// +optional
-	// +default=hello
+	// +default="hello"
 	greeting string,
 	// Change the name
 	// +optional
-	// +default=world
+	// +default="world"
 	name string,
 	// Encode the message in giant multi-character letters
 	// +optional

--- a/tailscale/main.go
+++ b/tailscale/main.go
@@ -21,7 +21,7 @@ type Tailscale struct{}
 func (m *Tailscale) Proxy(
 	ctx context.Context,
 	// Hostname of the proxy on the tailscale network
-	// +default=dagger-proxy
+	// +default="dagger-proxy"
 	hostname string,
 	// Backend for the proxy. All ports will be forwarded.
 	// if not specifed, a default test backend is used.

--- a/ttlsh/main.go
+++ b/ttlsh/main.go
@@ -20,7 +20,7 @@ func (m *Ttlsh) Publish(
 	repo string,
 	// the tag to publish to, defaults to 10m
 	// +optional
-	// +default=10m
+	// +default="10m"
 	tag string,
 ) (string, error) {
 	if repo == "" {


### PR DESCRIPTION
After merging https://github.com/dagger/dagger/pull/6683, which will be released for v0.9.11, this patch will be required to ensure that `default`s continue to work.

> [!WARNING]
>
> Ideally, only merge after v0.9.11 is released.

(thankfully, this time we have a nicer error message :heart:)

```
failed to convert method Hello to function def: default value "hello" must be valid JSON: invalid character 'h' looking for beginning of value
```