### PR TITLE
chore: fix engine versions to v0.11.9 release

### DIFF
--- a/dagger/dagger.json
+++ b/dagger/dagger.json
@@ -12,5 +12,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/dsh/dagger.json
+++ b/dsh/dagger.json
@@ -16,5 +16,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/hello/dagger.json
+++ b/hello/dagger.json
@@ -1,5 +1,5 @@
 {
   "name": "hello",
   "sdk": "go",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/slim/dagger.json
+++ b/slim/dagger.json
@@ -8,5 +8,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/tailscale/dagger.json
+++ b/tailscale/dagger.json
@@ -8,5 +8,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/termcast/dagger.json
+++ b/termcast/dagger.json
@@ -12,5 +12,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/utils/dagger.json
+++ b/utils/dagger.json
@@ -8,5 +8,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/wolfi/dagger.json
+++ b/wolfi/dagger.json
@@ -8,5 +8,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  "engineVersion": "v0.11.9"
 }

--- a/wolfi/main.go
+++ b/wolfi/main.go
@@ -4,6 +4,8 @@
 // https://wolfi.dev
 package main
 
+import "wolfi/internal/dagger"
+
 // A Wolfi Linux configuration
 type Wolfi struct{}
 
@@ -15,8 +17,8 @@ func (w *Wolfi) Container(
 	// Overlay images to merge on top of the base.
 	// See https://twitter.com/ibuildthecloud/status/1721306361999597884
 	// +optional
-	overlays []*Container,
-) *Container {
+	overlays []*dagger.Container,
+) *dagger.Container {
 	ctr := dag.Apko().Wolfi(packages)
 	for _, overlay := range overlays {
 		ctr = ctr.WithDirectory("/", overlay.Rootfs())


### PR DESCRIPTION
Without this, these modules are all interpreted as consuming the latest schema according to https://github.com/dagger/dagger/pull/7759 (there's no way of really doing anything else different).

We should fix these versions to ensure stability.