### PR TITLE
chore: bump apko to v0.1.11

### DIFF
--- a/wolfi/dagger.json
+++ b/wolfi/dagger.json
@@ -5,8 +5,8 @@
   "dependencies": [
     {
       "name": "apko",
-      "source": "github.com/vito/daggerverse/apko@apko/v0.1.10",
-      "pin": "3509a662fb698b5f0aaf38eaef9a9e0c9dc25d3a"
+      "source": "github.com/vito/daggerverse/apko@apko/v0.1.11",
+      "pin": "9eb5dc236f1ac718c4e54680930b6b98513a6416"
     }
   ],
   "source": "."


### PR DESCRIPTION
I get an error when installing `github.com/shykes/gha` with dagger v0.15.3

```
✘ .withExec(args: ["go", "build", "-o", "/bass", "./entrypoint"]): Container! 0.4s
# dagger.io/dagger/telemetry                                                                                                                                                                    
/go/pkg/mod/dagger.io/dagger@v0.12.2/telemetry/exporters.go:92:23: cannot use log (variable of type "go.opentelemetry.io/otel/sdk/log".Record) as *"go.opentelemetry                            
ue in argument to e.OnEmit                                                                                                                                                                      
! process "go build -o /bass ./entrypoint" did not complete successfully: exit code: 1
```

It seems like https://github.com/vito/daggerverse/commit/9eb5dc236f1ac718c4e54680930b6b98513a6416 is the fix for it

I'm not sure what the convention is on bumping the engine version, but since it's not bumped in apko, I figure it's fine to leave on v0.14.0 here?